### PR TITLE
Allow different names for workspace and repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,17 +11,18 @@
 The tool requires a `nq.toml` configuration file in the project root or any parent directory. The configuration format is:
 
 ```toml
-workspace_prefix = "relative/path/to/workspace"
+workspace_prefix = "relative/path/to/workspace"  # Optional, path to check for workspaces
 
-[patches.repo-name]
-repo = "repository-name"  # Optional, defaults to repo-name
+[patches.workspace-name]
+repo = "repository-name"  # Optional, defaults to workspace-name
 aliases = ["alias1", "alias2"]  # Optional, register alternative names for this repo when using the CLI
 ```
 
 ## Install nq
 You can install an editable `nq` on your system with
 ```bash
-pip install -e ./nq
+pip install -e .
+cd /path/to/my/repo
 nq list
 ```
 

--- a/nq/config.py
+++ b/nq/config.py
@@ -65,11 +65,14 @@ def get_repo_paths_for(name):
 
     patch = patches[name]
 
-    # Use patch name as repo name if not specified
-    repo = patch.get("repo", name)
+    # Use workspace name as repo name if `repo` is not specified
+    workspace_name = name
+    repo_name = patch.get("repo", workspace_name)
 
     # Construct paths
-    workspace_path = config["_config_dir"] / config["workspace_prefix"] / repo
-    repo_path = workspace_path / repo
+    workspace_path = (
+        config["_config_dir"] / config.get("workspace_prefix", "") / workspace_name
+    )
+    repo_path = workspace_path / repo_name
 
     return RepoInfo(name=name, workspace_path=workspace_path, repo_path=repo_path)


### PR DESCRIPTION
Let the list in patches refer to the name of the workspace. The repo name can be different than the workspace name now. Also, make the `workspace_prefix` optional

Closes #4 