### PR TITLE
Improve usability of Python API

### DIFF
--- a/nq/__init__.py
+++ b/nq/__init__.py
@@ -1,1 +1,5 @@
 """nq - A tool for managing patches in git repositories."""
+
+from .api import reset, apply, pull
+
+__all__ = ["reset", "apply", "pull"]

--- a/nq/api.py
+++ b/nq/api.py
@@ -1,0 +1,48 @@
+"""Public API for nq."""
+
+from .config import get_repo_paths_for
+from .cli import resolve_aliases
+from .patches import reset_repo, apply_patches, pull_repo
+
+
+def reset(name: str):
+    """Reset repository to submodule commit.
+
+    Args:
+        name: Name of the patch configuration
+
+    Returns:
+        True if successful, False otherwise
+    """
+    resolved_name = resolve_aliases(name)
+    repo_info = get_repo_paths_for(resolved_name)
+    return reset_repo(repo_info)
+
+
+def apply(name: str):
+    """Apply all patches from the workspace directory.
+
+    Args:
+        name: Name of the patch configuration
+
+    Returns:
+        True if successful, False otherwise
+    """
+    resolved_name = resolve_aliases(name)
+    repo_info = get_repo_paths_for(resolved_name)
+    return apply_patches(repo_info)
+
+
+def pull(name: str, commit_message=None):
+    """Pull latest changes from the remote repository.
+
+    Args:
+        name: Name of the patch configuration
+        commit_message: Optional commit message for the main repo
+
+    Returns:
+        True if successful, False otherwise
+    """
+    resolved_name = resolve_aliases(name)
+    repo_info = get_repo_paths_for(resolved_name)
+    return pull_repo(repo_info, commit_message=commit_message)

--- a/nq/cli.py
+++ b/nq/cli.py
@@ -16,6 +16,29 @@ from .patches import (
 )
 
 
+def resolve_aliases(name):
+    """Resolve a patch name to its canonical name by checking aliases.
+
+    Args:
+        name: The patch name or alias to resolve
+
+    Returns:
+        The resolved patch name (original name if no alias found)
+    """
+    config = load_config()
+    patches = config.get("patches", {})
+    resolved_name = name
+
+    # Check if the name is an alias for another patch
+    for patch_name, patch_config in patches.items():
+        aliases = patch_config.get("aliases", [])
+        if aliases and name in aliases:
+            resolved_name = patch_name
+            break
+
+    return resolved_name
+
+
 def main():
     """Main entry point for the nq command-line interface."""
     parser = argparse.ArgumentParser(
@@ -118,16 +141,7 @@ def main():
         args.name = submodule_name
 
     # Resolve aliases
-    config = load_config()
-    patches = config.get("patches", {})
-    resolved_name = args.name
-
-    # Check if the name is an alias for another patch
-    for patch_name, patch_config in patches.items():
-        aliases = patch_config.get("aliases", [])
-        if aliases and args.name in aliases:
-            resolved_name = patch_name
-            break
+    resolved_name = resolve_aliases(args.name)
 
     # Convert name to workspace path
     repo_info = get_repo_paths_for(resolved_name)

--- a/nq/patches.py
+++ b/nq/patches.py
@@ -294,19 +294,3 @@ def print_status(repo_info: RepoInfo):
             print("  * Warning: Current changes don't match existing patches")
 
     return True
-
-
-# Public API functions
-def reset(repo_info: RepoInfo):
-    """Reset repository to submodule commit."""
-    return reset_repo(repo_info)
-
-
-def apply(repo_info: RepoInfo):
-    """Apply all patches from the workspace directory."""
-    return apply_patches(repo_info)
-
-
-def pull(repo_info: RepoInfo, commit_message=None):
-    """Pull latest changes from the remote repository."""
-    return pull_repo(repo_info, commit_message=commit_message)


### PR DESCRIPTION
- Now can use `nq.reset(NAME)` instead of `nq.patches.reset(NQ_INTERNAL)`
- Move all of the API functions into `api.py`
- Make `resolve_aliases` an independent function so that the API functions can use this to resolve `nq` aliases