### PR TITLE
Various API enhancements

### DIFF
--- a/nq/__init__.py
+++ b/nq/__init__.py
@@ -1,5 +1,5 @@
 """nq - A tool for managing patches in git repositories."""
 
-from .api import reset, apply, pull
+from .api import reset, apply, pull, status, export
 
-__all__ = ["reset", "apply", "pull"]
+__all__ = ["reset", "apply", "pull", "status", "export"]

--- a/nq/api.py
+++ b/nq/api.py
@@ -3,10 +3,10 @@
 from .config import get_repo_paths_for
 from .cli import resolve_aliases
 from .patches import reset_repo, apply_patches, pull_repo, export_patches, ApplyResult
-from .git import get_repo_status, check_repo_is_committed, StatusResult
+from .git import get_repo_status, StatusResult
 
 
-def reset(name: str, allow_uncommitted_changes=False):
+def reset(name: str, force=False):
     """Reset repository to submodule commit.
 
     Args:
@@ -17,7 +17,7 @@ def reset(name: str, allow_uncommitted_changes=False):
     """
     resolved_name = resolve_aliases(name)
     repo_info = get_repo_paths_for(resolved_name)
-    return reset_repo(repo_info, allow_uncommitted_changes=allow_uncommitted_changes)
+    return reset_repo(repo_info, force=force)
 
 
 def apply(name: str) -> ApplyResult:
@@ -62,8 +62,6 @@ def export(name: str) -> bool:
     """
     resolved_name = resolve_aliases(name)
     repo_info = get_repo_paths_for(resolved_name)
-    if not check_repo_is_committed(repo_info):
-        return False
     if not export_patches(repo_info):
         return False
     return True
@@ -72,15 +70,15 @@ def export(name: str) -> bool:
 def pull(
     name: str,
     commit_message=None,
-    commit_sha=None,
-    allow_uncommitted_changes=False,
+    ref=None,
+    allow_dirty_main_repo=False,
 ):
     """Pull latest changes from the remote repository.
 
     Args:
         name: Name of the patch configuration
         commit_message: Optional commit message for the main repo
-        commit_sha: Optional commit SHA to pull a specific commit
+        ref: Optional ref to pull a specific reference. Defaults to the latest on the default branch.
 
     Returns:
         True if successful, False otherwise
@@ -90,6 +88,6 @@ def pull(
     return pull_repo(
         repo_info,
         commit_message=commit_message,
-        commit_sha=commit_sha,
-        allow_uncommitted_changes=allow_uncommitted_changes,
+        ref=ref,
+        allow_dirty_main_repo=allow_dirty_main_repo,
     )

--- a/nq/api.py
+++ b/nq/api.py
@@ -2,10 +2,11 @@
 
 from .config import get_repo_paths_for
 from .cli import resolve_aliases
-from .patches import reset_repo, apply_patches, pull_repo
+from .patches import reset_repo, apply_patches, pull_repo, export_patches, ApplyResult
+from .git import get_repo_status, check_repo_is_committed, StatusResult
 
 
-def reset(name: str):
+def reset(name: str, allow_uncommitted_changes=False):
     """Reset repository to submodule commit.
 
     Args:
@@ -16,10 +17,10 @@ def reset(name: str):
     """
     resolved_name = resolve_aliases(name)
     repo_info = get_repo_paths_for(resolved_name)
-    return reset_repo(repo_info)
+    return reset_repo(repo_info, allow_uncommitted_changes=allow_uncommitted_changes)
 
 
-def apply(name: str):
+def apply(name: str) -> ApplyResult:
     """Apply all patches from the workspace directory.
 
     Args:
@@ -33,16 +34,62 @@ def apply(name: str):
     return apply_patches(repo_info)
 
 
-def pull(name: str, commit_message=None):
-    """Pull latest changes from the remote repository.
+def status(name: str) -> StatusResult:
+    """Gets the status of an nq repo
 
     Args:
         name: Name of the patch configuration
-        commit_message: Optional commit message for the main repo
+
+    Returns:
+        StatusResult object containing the status of the repository
+    """
+    resolved_name = resolve_aliases(name)
+    repo_info = get_repo_paths_for(resolved_name)
+    return get_repo_status(repo_info)
+
+
+def export(name: str) -> bool:
+    """
+    Creates numbered patch files from new commits in the submodule
+
+    Requires the submodule to be in a fully committed state.
+
+    Args:
+        name: Name of the patch configuration
 
     Returns:
         True if successful, False otherwise
     """
     resolved_name = resolve_aliases(name)
     repo_info = get_repo_paths_for(resolved_name)
-    return pull_repo(repo_info, commit_message=commit_message)
+    if not check_repo_is_committed(repo_info):
+        return False
+    if not export_patches(repo_info):
+        return False
+    return True
+
+
+def pull(
+    name: str,
+    commit_message=None,
+    commit_sha=None,
+    allow_uncommitted_changes=False,
+):
+    """Pull latest changes from the remote repository.
+
+    Args:
+        name: Name of the patch configuration
+        commit_message: Optional commit message for the main repo
+        commit_sha: Optional commit SHA to pull a specific commit
+
+    Returns:
+        True if successful, False otherwise
+    """
+    resolved_name = resolve_aliases(name)
+    repo_info = get_repo_paths_for(resolved_name)
+    return pull_repo(
+        repo_info,
+        commit_message=commit_message,
+        commit_sha=commit_sha,
+        allow_uncommitted_changes=allow_uncommitted_changes,
+    )

--- a/nq/api.py
+++ b/nq/api.py
@@ -79,6 +79,8 @@ def pull(
         name: Name of the patch configuration
         commit_message: Optional commit message for the main repo
         ref: Optional ref to pull a specific reference. Defaults to the latest on the default branch.
+        allow_dirty_main_repo: Allow pulling changes when the main repo has uncommitted changes.
+                               Unstaged changes never allowed, since this command commits.
 
     Returns:
         True if successful, False otherwise

--- a/nq/cli.py
+++ b/nq/cli.py
@@ -85,7 +85,10 @@ def main():
     reset_parser.add_argument(
         "--force",
         action="store_true",
-        help="forcefully reset the repository even if there are uncommitted changes",
+        help=(
+            "Reset the repository even if there are uncommitted or unexported changes."
+            "This will destroy unexported dev work"
+        ),
     )
 
     # Status command

--- a/nq/patches.py
+++ b/nq/patches.py
@@ -65,7 +65,11 @@ def reset_repo(repo_info: RepoInfo, force=False):
     # - no patches exist, or
     # - patches exist but don't match current commits
     # then we should prevent cleaning to avoid losing work
-    if not status.is_clean and (not status.patches_exist or not status.patches_applied):
+    if (
+        not force
+        and not status.is_clean
+        and (not status.patches_exist or not status.patches_applied)
+    ):
         print(
             "Error: Cannot reset - you have commits that haven't been exported.",
             file=sys.stderr,
@@ -141,7 +145,7 @@ def pull_repo(
     # pull default branch if ref is not specified
     if ref is None:
         # Reset to submodule commit first if not using a specific commit SHA
-        if not reset_repo(repo_info, allow_dirty_main_repo=allow_dirty_main_repo):
+        if not reset_repo(repo_info):
             return False
 
         # Get the default branch using symbolic-ref

--- a/nq/patches.py
+++ b/nq/patches.py
@@ -3,7 +3,6 @@
 import re
 import subprocess
 import sys
-from typing import NamedTuple
 from pathlib import Path
 
 from .config import RepoInfo, get_package_paths, load_config
@@ -321,11 +320,20 @@ def _get_pending_git_files(repo_path: Path) -> list[Path]:
         return []
 
 
-class ApplyResult(NamedTuple):
+class ApplyResult:
     """Result of a call to apply"""
 
-    success: bool
-    failed_target_files: list[Path] = []
+    def __init__(self, success: bool, failed_target_files: list[Path] = None):
+        self.success = success
+        self.failed_target_files = failed_target_files or []
+
+    def __bool__(self) -> bool:
+        """Convert to boolean - returns True if the operation was successful."""
+        return self.success
+
+    def __repr__(self) -> str:
+        """String representation of the result."""
+        return f"ApplyResult(success={self.success}, failed_target_files={self.failed_target_files})"
 
 
 def apply_patches(repo_info: RepoInfo) -> ApplyResult:


### PR DESCRIPTION
### Overview
- Adds `export` and `status` to the public API (were previously only in cli)
- Returns an `ApplyResult` after running `apply` from the public API
  - This result contains absolute paths to files that could not have patches applied, so that clients can use this information to know where the files are that they need to resolve conflicts
- Adds `force` arg to reset, so that you can reset the submodule commit of a repo without requiring the whole current repo state to be clean. Defaults to `false` to preserve prior safety when you don't explicitly want this
- Adds `commit_sha` arg to `pull_repo`, so that you can pull any commit from a nq repo instead of just the latest on the default branch. Still defaults to the latest on the default branch