### PR TITLE
Update expected structure, and add patches path

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The expectation is that your patches are placed in a dir named `patches`, and th
 workspace_prefix
 ├── patches
 │   └── torch
-│       └── 0001-improve-kernel-performance
+│       └── 0001-improve-kernel-performance.patch
 └── src
     └── torch
 

--- a/README.md
+++ b/README.md
@@ -18,12 +18,22 @@ repo = "repository-name"  # Optional, defaults to workspace-name
 aliases = ["alias1", "alias2"]  # Optional, register alternative names for this repo when using the CLI
 ```
 
-## Install nq
-You can install an editable `nq` on your system with
+The expectation is that your patches are placed in a dir named `patches`, and the submodules are placed in `src`. Example:
 ```bash
-pip install -e .
-cd /path/to/my/repo
-nq list
+workspace_prefix
+├── patches
+│   └── torch
+│       └── 0001-improve-kernel-performance
+└── src
+    └── torch
+
+```
+
+## Install nq
+
+Install the latest version of `nq`:
+```bash
+pip install git+https://github.com/lmstudio-ai/nq.git
 ```
 
 ## Commands

--- a/nq/config.py
+++ b/nq/config.py
@@ -11,6 +11,7 @@ class RepoInfo(NamedTuple):
     name: str
     workspace_path: Path
     repo_path: Path
+    patches_path: Path
 
 
 def load_config():
@@ -33,11 +34,11 @@ def load_config():
         current = parent
 
 
-def get_package_paths() -> List[str]:
-    """Get all package names from nq.toml.
+def get_package_paths() -> List[RepoInfo]:
+    """Get all package paths from nq.toml.
 
     Returns:
-        List of package names defined in the configuration
+        List of RepoInfo objects for all packages defined in the configuration
     """
     config = load_config()
     result = []
@@ -48,13 +49,13 @@ def get_package_paths() -> List[str]:
 
 
 def get_repo_paths_for(name):
-    """Get workspace and repo paths for a given patch name.
+    """Get workspace, repo, and patches paths for a given patch name.
 
     Args:
         name: Name of the patch to look up
 
     Returns:
-        Paths namedtuple containing workspace_path and repo_path
+        RepoInfo namedtuple containing workspace_path, repo_path, and patches_path
     """
     config = load_config()
     patches = config.get("patches", {})
@@ -70,9 +71,13 @@ def get_repo_paths_for(name):
     repo_name = patch.get("repo", workspace_name)
 
     # Construct paths
-    workspace_path = (
-        config["_config_dir"] / config.get("workspace_prefix", "") / workspace_name
-    )
-    repo_path = workspace_path / repo_name
+    workspace_path = config["_config_dir"] / config.get("workspace_prefix", "")
+    repo_path = workspace_path / "src" / repo_name
+    patches_path = workspace_path / "patches" / workspace_name
 
-    return RepoInfo(name=name, workspace_path=workspace_path, repo_path=repo_path)
+    return RepoInfo(
+        name=name,
+        workspace_path=workspace_path,
+        repo_path=repo_path,
+        patches_path=patches_path,
+    )


### PR DESCRIPTION
Refactor the `nq` structure, so that we can track multiple patchsets for the same submodule.

Place all of the patches in a `patches` directory, and place the source code in `src`. This decouples the patches from the source code, so we can define multiple patchlists per repo