### PR TITLE
Remove src hard-code for repo path

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The tool requires a `nq.toml` configuration file in the project root or any pare
 workspace_prefix = "relative/path/to/workspace"  # Optional, path to check for workspaces
 
 [patches.workspace-name]
-repo = "repository-name"  # Optional, defaults to workspace-name
+repo = "src/repository-name"  # Optional, defaults to workspace-name
 aliases = ["alias1", "alias2"]  # Optional, register alternative names for this repo when using the CLI
 ```
 

--- a/nq/config.py
+++ b/nq/config.py
@@ -68,11 +68,11 @@ def get_repo_paths_for(name):
 
     # Use workspace name as repo name if `repo` is not specified
     workspace_name = name
-    repo_name = patch.get("repo", workspace_name)
+    repo_path = Path(patch.get("repo", workspace_name))
 
     # Construct paths
     workspace_path = config["_config_dir"] / config.get("workspace_prefix", "")
-    repo_path = workspace_path / "src" / repo_name
+    repo_path = workspace_path / repo_path
     patches_path = workspace_path / "patches" / workspace_name
 
     return RepoInfo(


### PR DESCRIPTION
The submodule needed to be in a `src` subpath, which limits directory structure flexibility. Now, if a user wants to use subdirectories, they must specify the path.